### PR TITLE
chore(security): pin actions to specific commits

### DIFF
--- a/.github/workflows/daily-supply-chain-reports.yml
+++ b/.github/workflows/daily-supply-chain-reports.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 on 2025-06-26, TODO: consider using a release
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 on 2025-06-26, TODO: consider using a release
       with:
         node-version: '20'
         


### PR DESCRIPTION
Third-party Github Actions should be referenced by commmit hash instead of tags or versions.

Git tags and branches are not immutable (commit hashes are), and the code for an action 'pinned' to a tag or branch may change:

- Git tags can be deleted and pointed to a different commit hence insecure.
- Git branches always reference the latest commit in that branch hence non deterministic.

This means that if the repo containing the third party action is compromised in some way, malicious code will enter the build pipeline.
