### PR TITLE
security: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/daily-supply-chain-reports.yml
+++ b/.github/workflows/daily-supply-chain-reports.yml
@@ -13,14 +13,18 @@ permissions:
 
 jobs:
   fetch-supply-chain-reports:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     steps:
+    - name: Harden the runner
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 on 2026-04-09
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 on 2026-04-09
       with:
         node-version: '20'
         

--- a/.github/workflows/flowlyt-scan.yml
+++ b/.github/workflows/flowlyt-scan.yml
@@ -10,14 +10,18 @@ permissions:
 jobs:
   analyze:
     name: Flowlyt security scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 on 2026-04-09
 
       - name: Run Flowlyt Security Scan
-        uses: harekrishnarai/flowlyt@v1.0.5
+        uses: harekrishnarai/flowlyt@d54efdc4a631cb6e121067e1b0bb3eda3708b153 # v1.0.5 on 2026-04-09
         with:
           # don't pass config-file or enable-ast-analysis (these are not required / invalid)
           repository: .
@@ -36,6 +40,6 @@ jobs:
           continue-on-error: 'false'
           verbose: 'false'
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@3b1a19a80ab047f35cbb237b5bd9bdc1e14f166c # v3 on 2026-04-09
         with:
           sarif_file: flowlyt-results.sarif


### PR DESCRIPTION
## Summary

This PR applies the following supply-chain hardening to your GitHub Actions workflows:

- **Action pinning**: 5 `uses:` reference(s) pinned to immutable commit SHAs
- **Harden Runner**: `step-security/harden-runner` injected into 2 job(s) (egress-policy: `audit`)
- **Runner pinning**: 2 runner label(s) replaced with versioned equivalents

## Benefits

- **Security**: Immutable action references prevent supply chain attacks
- **Reproducibility**: Same action version is guaranteed across all runs
- **Auditability**: Comments preserve the original version tag for easy reference
- **Runtime protection**: Harden Runner monitors/blocks unexpected outbound network calls
- **Runner stability**: Versioned runner labels prevent unexpected environment changes

## Review Notes

- All pinned actions maintain their original functionality
- No workflow behavior changes are expected
